### PR TITLE
deps: update jsdom for Node 4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^0.9.0",
-    "jsdom": "^2.0.0",
+    "jsdom": "^7.0.2",
     "slug": "^0.8.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Right now, jsdom uses Contextify, which causes build issues when installed with Node 4. The latest version of Contextify does not cause build issues.

Tests pass. Closes #1.
