### PR TITLE
Properly handle escaped HTML characters in heading text

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function(options) {
     headers = headers.map(function(header) {
       return {
         id: header.id,
-        text: header.innerHTML,
+        text: header.textContent,
         level: parseInt(header.tagName.match(/^h([123456])$/i)[1], 10)
       };
     });
@@ -131,7 +131,7 @@ module.exports = function(options) {
             var headers = Array.prototype.slice.call(
               window.document.querySelectorAll(file.autotocSelector || options.selector || 'h3, h4')
             ).map(function(header) {
-              header.id = options.slug(header.innerHTML, header.id);
+              header.id = options.slug(header.textContent, header.id);
               return header;
             });
 

--- a/test/fixtures/basic/build/index.html
+++ b/test/fixtures/basic/build/index.html
@@ -12,7 +12,7 @@
     
   </li>
   
-  <li><a href="#foo-ccc">ccc</a>
+  <li><a href="#foo-candc">c&amp;c</a>
     
   </li>
   
@@ -20,8 +20,16 @@
 
   </li>
   
-  <li><a href="#foo-ddd">ddd</a>
+  <li><a href="#foo-Quotey-Quotes">'Quotey' Quotes</a>
     
+<ol class="toc">
+  
+  <li><a href="#foo-lessanglegreater">&lt;angle&gt; 💩</a>
+    
+  </li>
+  
+</ol>
+
   </li>
   
 </ol>
@@ -34,9 +42,12 @@
 <h3 id="foo-bbb">bbb</h3>
 <p>paragraph</p>
 
-<h3 id="foo-ccc">ccc</h3>
+<h3 id="foo-candc">c&amp;c</h3>
 <p>paragraph</p>
 
-<h2 id="foo-ddd">ddd</h2>
+<h2 id="foo-Quotey-Quotes">'Quotey' Quotes</h2>
+<p>paragraph</p>
+
+<h3 id="foo-lessanglegreater">&lt;angle&gt; 💩</h3>
 <p>paragraph</p>
 

--- a/test/fixtures/basic/expected/index.html
+++ b/test/fixtures/basic/expected/index.html
@@ -12,7 +12,7 @@
     
   </li>
   
-  <li><a href="#foo-ccc">ccc</a>
+  <li><a href="#foo-candc">c&amp;c</a>
     
   </li>
   
@@ -20,8 +20,16 @@
 
   </li>
   
-  <li><a href="#foo-ddd">ddd</a>
+  <li><a href="#foo-Quotey-Quotes">'Quotey' Quotes</a>
     
+<ol class="toc">
+  
+  <li><a href="#foo-lessanglegreater">&lt;angle&gt; 💩</a>
+    
+  </li>
+  
+</ol>
+
   </li>
   
 </ol>
@@ -34,9 +42,12 @@
 <h3 id="foo-bbb">bbb</h3>
 <p>paragraph</p>
 
-<h3 id="foo-ccc">ccc</h3>
+<h3 id="foo-candc">c&amp;c</h3>
 <p>paragraph</p>
 
-<h2 id="foo-ddd">ddd</h2>
+<h2 id="foo-Quotey-Quotes">'Quotey' Quotes</h2>
+<p>paragraph</p>
+
+<h3 id="foo-lessanglegreater">&lt;angle&gt; 💩</h3>
 <p>paragraph</p>
 

--- a/test/fixtures/basic/src/index.html
+++ b/test/fixtures/basic/src/index.html
@@ -9,8 +9,11 @@ template: 'layout.eco'
 <h3>bbb</h3>
 <p>paragraph</p>
 
-<h3>ccc</h3>
+<h3>c&amp;c</h3>
 <p>paragraph</p>
 
-<h2>ddd</h2>
+<h2>'Quotey' Quotes</h2>
+<p>paragraph</p>
+
+<h3>&lt;angle&gt; 💩</h3>
 <p>paragraph</p>


### PR DESCRIPTION
Fixes a bug where escaped HTML entities (`&amp;`, `&lt;`, etc.) get double-escaped on output.