### PR TITLE
h1 can now be the root of the table of contents.

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function(options) {
   function getRootLevel(headers) {
     return headers.map(function(header) {
       return header.level;
-    }).sort()[0] - 1 || 1;
+    }).sort()[0] - 1;
   }
 
   function buildTocItems(headers) {

--- a/test/fixtures/h1/build/index.html
+++ b/test/fixtures/h1/build/index.html
@@ -1,0 +1,42 @@
+
+
+
+
+<ol class="toc">
+  
+  <li><a href="#aaa">aaa</a>
+    
+<ol class="toc">
+  
+  <li><a href="#bbb">bbb</a>
+    
+  </li>
+  
+  <li><a href="#ccc">ccc</a>
+    
+  </li>
+  
+</ol>
+
+  </li>
+  
+  <li><a href="#ddd">ddd</a>
+    
+  </li>
+  
+</ol>
+
+
+
+<h1 id="aaa">aaa</h1>
+<p>paragraph</p>
+
+<h2 id="bbb">bbb</h2>
+<p>paragraph</p>
+
+<h2 id="ccc">ccc</h2>
+<p>paragraph</p>
+
+<h1 id="ddd">ddd</h1>
+<p>paragraph</p>
+

--- a/test/fixtures/h1/expected/index.html
+++ b/test/fixtures/h1/expected/index.html
@@ -1,0 +1,42 @@
+
+
+
+
+<ol class="toc">
+  
+  <li><a href="#aaa">aaa</a>
+    
+<ol class="toc">
+  
+  <li><a href="#bbb">bbb</a>
+    
+  </li>
+  
+  <li><a href="#ccc">ccc</a>
+    
+  </li>
+  
+</ol>
+
+  </li>
+  
+  <li><a href="#ddd">ddd</a>
+    
+  </li>
+  
+</ol>
+
+
+
+<h1 id="aaa">aaa</h1>
+<p>paragraph</p>
+
+<h2 id="bbb">bbb</h2>
+<p>paragraph</p>
+
+<h2 id="ccc">ccc</h2>
+<p>paragraph</p>
+
+<h1 id="ddd">ddd</h1>
+<p>paragraph</p>
+

--- a/test/fixtures/h1/src/index.html
+++ b/test/fixtures/h1/src/index.html
@@ -1,0 +1,16 @@
+---
+title: 'hoge'
+autotoc: true
+template: 'layout.eco'
+---
+<h1>aaa</h1>
+<p>paragraph</p>
+
+<h2>bbb</h2>
+<p>paragraph</p>
+
+<h2>ccc</h2>
+<p>paragraph</p>
+
+<h1>ddd</h1>
+<p>paragraph</p>

--- a/test/fixtures/h1/templates/layout.eco
+++ b/test/fixtures/h1/templates/layout.eco
@@ -1,0 +1,15 @@
+<% renderToc = (items) => %>
+<ol class="toc">
+  <% for item in items: %>
+  <li><a href="#<%= item.id %>"><%= item.text %></a>
+    <% if item.children.length > 0: %><%- renderToc(item.children) %><% end %>
+  </li>
+  <% end %>
+</ol>
+<% end %>
+
+<% if @toc: %>
+<%- renderToc(@toc) %>
+<% end %>
+
+<%- @contents %>

--- a/test/index.js
+++ b/test/index.js
@@ -23,4 +23,22 @@ describe('metalsmith-autotoc', function() {
         done();
       });
   });
+
+  it('should allow table of contents to include h1', function(done) {
+    metalsmith(__dirname + '/fixtures/h1')
+      .use(autotoc({
+        selector: 'h1, h2, h3'
+      }))
+      .use(templates({
+        engine: 'eco',
+        directory: './templates'
+      }))
+      .build(function(error) {
+        if (error) {
+          throw error;
+        }
+        equal('test/fixtures/h1/expected', 'test/fixtures/h1/build');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
Fixes a bug that doesn't allow you to use `h1` as part of your selector.